### PR TITLE
future.ret is deprecated in meteor 0.6.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ Meteor.sync = function(asynFunction) {
           result: result,
           error: err
         };
-        future.ret();
+        future.return();
       }
     }
   }, 0);


### PR DESCRIPTION
See https://github.com/meteor/meteor/issues/1311
