### PR TITLE
Windows fix: use mkdirp, rimraf and node-echo instead of native posix commands

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,11 @@ Package._transitional_registerBuildPlugin({
   sources: [
     'plugin/init_npm.js'
   ],
-  npmDependencies: {}
+  npmDependencies: {
+    'mkdirp': '0.5.0',
+    'rimraf': '2.2.8',
+    'node-echo': '0.1.1'
+  }
 });
 
 Package.onUse(function (api, where) {

--- a/plugin/init_npm.js
+++ b/plugin/init_npm.js
@@ -2,6 +2,9 @@ var path = Npm.require('path');
 var fs = Npm.require('fs');
 var Future = Npm.require('fibers/future');
 var exec = Npm.require('child_process').exec;
+var mkdirp = Npm.require('mkdirp');
+var rimraf = Npm.require('rimraf');
+var echo = Npm.require('node-echo');
 
 var oldNpmPackageDir = path.resolve('./packages/npm');
 var npmContainerDir = path.resolve('./packages/npm-container');
@@ -22,15 +25,18 @@ if(canProceed() && !fs.existsSync(npmContainerDir)) {
   var packageJsPath = path.resolve(npmContainerDir, 'package.js');
   var indexJsPath = path.resolve(npmContainerDir, 'index.js');
   // create new npm container directory
-  execSync("mkdir -p '" + npmContainerDir + "'");
+  mkdirp.sync(npmContainerDir);
   // add package files
   fs.writeFileSync(indexJsPath, getContent(_indexJsContent));
   fs.writeFileSync(packageJsPath, getContent(_packageJsContent));
 
   // remove old npm package if exists
-  execSync("rm -rf '" + oldNpmPackageDir + "'");
+  if (fs.existsSync(oldNpmPackageDir)) {
+    rimraf.sync(oldNpmPackageDir);
+  }
+  
   // add new container as a package
-  execSync('echo "\nnpm-container" >> .meteor/packages');
+  echo.sync("\nnpm-container", ">>", ".meteor/packages")
 
   console.log();
   console.log("-> npm support has been initialized.")


### PR DESCRIPTION
This pull request fixes some Windows incompatible code (see https://github.com/meteor/windows-preview/issues/13).

Note that there is another issue (https://github.com/meteor/windows-preview/issues/5) with requiring npm modules in packages in the meteor windows preview which will still break this package. Check the issue for a temporary workaround.

A minor problem still is that `process.exit(0)` will not properly terminate MongoDB which requires a `meteor reset` after npm support has been initialized.
