### PR TITLE
Meteor 1.2 rc11+ deprecates {isAsset:true} for api.addAsset()

### DIFF
--- a/plugin/init_npm.js
+++ b/plugin/init_npm.js
@@ -128,7 +128,7 @@ function _packageJsContent () {
   // Adding the app's packages.json as a used file for this package will get
   // Meteor to watch it and reload this package when it changes
   Package.onUse(function(api) {
-    api.add_files('index.js', 'server');
-    api.add_files('../../packages.json', 'server', {isAsset: true});
+    api.addFiles('index.js', 'server');
+    api.addAsset('../../packages.json', 'server');
   });
 }


### PR DESCRIPTION
Also tweaked the `add_files` to `addFiles` while I was in there.
